### PR TITLE
Add filter to require a specific package

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ final class Plugin implements GenerativePlugin
     /** @inheritDoc */
     public function filters(): iterable
     {
+        yield new ComposerJsonRequiresSpecificPackage('wyrihaximus/broadcast-contracts', PackageType::PRODUCTION);
         yield new ComposerJsonHasItemWithSpecificValue('wyrihaximus.broadcast.has-listeners', true);
         yield new ImplementsInterface(Listener::class, AsyncListener::class);
         yield new IsInstantiable();
@@ -305,6 +306,26 @@ Only packages with this in their `composer.json` are considered:
             "has-listeners": true
         }
     }
+  }
+}
+```
+
+### ComposerJsonRequiresSpecificPackage
+
+Only consider packages that require a specific package in it's `composer.json`.
+
+So with the following arguments:
+
+```php
+new ComposerJsonRequiresSpecificPackage('wyrihaximus/simple-twig', PackageType::PRODUCTION)
+```
+
+Only packages with this in their `composer.json` are considered:
+
+```json
+{
+  "require": {
+    "wyrihaximus/simple-twig": "^2.2.1"
   }
 }
 ```

--- a/src/Filter/Package/ComposerJsonRequiresSpecificPackage.php
+++ b/src/Filter/Package/ComposerJsonRequiresSpecificPackage.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WyriHaximus\Composer\GenerativePluginTooling\Filter\Package;
+
+use Composer\Package\PackageInterface;
+use WyriHaximus\Composer\GenerativePluginTooling\PackageFilter;
+
+/** @api */
+final readonly class ComposerJsonRequiresSpecificPackage implements PackageFilter
+{
+    private const bool PACKAGE_FOUND_RETURN     = true;
+    private const bool PACKAGE_NOT_FOUND_RETURN = false;
+
+    public function __construct(private string $package, private PackageType $type)
+    {
+    }
+
+    public function __invoke(PackageInterface $package): bool
+    {
+        $links = $this->type === PackageType::PRODUCTION ? $package->getRequires() : $package->getDevRequires();
+        foreach ($links as $link) {
+            if ($link->getTarget() === $this->package) {
+                return self::PACKAGE_FOUND_RETURN;
+            }
+        }
+
+        return self::PACKAGE_NOT_FOUND_RETURN;
+    }
+}

--- a/src/Filter/Package/PackageType.php
+++ b/src/Filter/Package/PackageType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WyriHaximus\Composer\GenerativePluginTooling\Filter\Package;
+
+enum PackageType: string
+{
+    case PRODUCTION  = 'prod';
+    case DEVELOPMENT = 'dev';
+}

--- a/tests/Plugin.php
+++ b/tests/Plugin.php
@@ -11,6 +11,8 @@ use WyriHaximus\Composer\GenerativePluginTooling\Filter\Operators\LogicalAnd;
 use WyriHaximus\Composer\GenerativePluginTooling\Filter\Operators\LogicalNot;
 use WyriHaximus\Composer\GenerativePluginTooling\Filter\Operators\LogicalOr;
 use WyriHaximus\Composer\GenerativePluginTooling\Filter\Package\ComposerJsonHasItemWithSpecificValue;
+use WyriHaximus\Composer\GenerativePluginTooling\Filter\Package\ComposerJsonRequiresSpecificPackage;
+use WyriHaximus\Composer\GenerativePluginTooling\Filter\Package\PackageType;
 use WyriHaximus\Composer\GenerativePluginTooling\GenerativePlugin;
 use WyriHaximus\Composer\GenerativePluginTooling\Item as ItemContract;
 use WyriHaximus\Composer\GenerativePluginTooling\LogStages;
@@ -41,6 +43,8 @@ final class Plugin implements GenerativePlugin
     {
         yield from LogicalAnd::create(
             ...LogicalOr::create(
+                new ComposerJsonRequiresSpecificPackage('wyrihaximus/simple-twig', PackageType::PRODUCTION),
+                new ComposerJsonRequiresSpecificPackage('wyrihaximus/simple-twig', PackageType::DEVELOPMENT),
                 new ComposerJsonHasItemWithSpecificValue('wyrihaximus.broadcast.has-listeners', true),
                 new ComposerJsonHasItemWithSpecificValue('wyrihaximus.broadcast.has-listeners', true),
             ),

--- a/tests/apps/broadcast/composer.json
+++ b/tests/apps/broadcast/composer.json
@@ -1,5 +1,8 @@
 {
   "name": "wyrihaximus/makefiles",
+  "require": {
+    "wyrihaximus/simple-twig": "^2.2.1"
+  },
   "autoload": {
     "psr-4": {
       "WyriHaximus\\Broadcast\\": "src"


### PR DESCRIPTION
Only consider packages that require a specific package in it's `composer.json`.

So with the following arguments:

```php
new ComposerJsonRequiresSpecificPackage('wyrihaximus/simple-twig', PackageType::PRODUCTION)
```

Only packages with this in their `composer.json` are considered:

```json
{
  "require": {
    "wyrihaximus/simple-twig": "^2.2.1"
  }
}
```