### PR TITLE
Introduce Failed Reflections Store Singleton

### DIFF
--- a/src/FailedReflectionsStore.php
+++ b/src/FailedReflectionsStore.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace WyriHaximus\Composer\GenerativePluginTooling;
+
+use function array_key_exists;
+
+final class FailedReflectionsStore
+{
+    private static self|null $instance = null;
+
+    /** @var array<class-string, true> */
+    private array $knownFailedReflections = [];
+
+    private static function instance(): self
+    {
+        if (! self::$instance instanceof self) {
+            self::$instance = new self();
+        }
+
+        return self::$instance;
+    }
+
+    /** @param class-string $classname */
+    public static function has(string $classname): bool
+    {
+        return array_key_exists($classname, self::instance()->knownFailedReflections);
+    }
+
+    /** @param class-string $classname */
+    public static function add(string $classname): void
+    {
+        self::instance()->knownFailedReflections[$classname] = true;
+    }
+
+    /**
+     * @internal
+     *
+     * @phpstan-ignore shipmonk.deadMethod
+     */
+    public static function reset(): void
+    {
+        self::instance()->knownFailedReflections = [];
+    }
+}

--- a/src/GenerativePluginExecutioner.php
+++ b/src/GenerativePluginExecutioner.php
@@ -228,7 +228,14 @@ final class GenerativePluginExecutioner
     private static function listReflectedClassesInPaths(GenerativePlugin $plugin, IOInterface $io, string $vendorDir, string $path): iterable
     {
         $classReflector = self::createClassReflector($vendorDir);
+        /**
+         * @var class-string $class
+         */
         foreach (self::listClassesInPaths($path) as $class) {
+            if (FailedReflectionsStore::has($class)) {
+                continue;
+            }
+
             try {
                 yield (static function (ReflectionClass $reflectionClass): ReflectionClass {
                     /**
@@ -242,6 +249,8 @@ final class GenerativePluginExecutioner
                     return $reflectionClass;
                 })($classReflector->reflectClass($class));
             } catch (IdentifierNotFound $identifierNotFound) {
+                FailedReflectionsStore::add($class);
+
                 $io->write(sprintf(
                     '<error>' . $plugin::name() . ':</error> ' . $plugin::log(LogStages::Error),
                     sprintf(

--- a/tests/GenerativePluginExecutionerTest.php
+++ b/tests/GenerativePluginExecutionerTest.php
@@ -12,12 +12,14 @@ use Composer\Package\RootPackage;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Repository\RepositoryManager;
 use Mockery;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Output\StreamOutput;
 use WyriHaximus\Broadcast\Dummy\AsyncListener;
 use WyriHaximus\Broadcast\Dummy\Event;
 use WyriHaximus\Broadcast\Dummy\Listener;
+use WyriHaximus\Composer\GenerativePluginTooling\FailedReflectionsStore;
 use WyriHaximus\Composer\GenerativePluginTooling\GenerativePluginExecutioner;
 use WyriHaximus\Composer\GenerativePluginTooling\Item as ItemContract;
 use WyriHaximus\TestUtilities\TestCase;
@@ -151,5 +153,11 @@ final class GenerativePluginExecutionerTest extends TestCase
         usort($items, static fn (ItemContract $a, ItemContract $b): int => (string) json_encode($a) <=> (string) json_encode($b));
 
         yield from $items;
+    }
+
+    #[Before]
+    public function resetRFS(): void
+    {
+        FailedReflectionsStore::reset();
     }
 }

--- a/tests/OperatorsTest.php
+++ b/tests/OperatorsTest.php
@@ -12,12 +12,14 @@ use Composer\Package\RootPackage;
 use Composer\Repository\InstalledRepositoryInterface;
 use Composer\Repository\RepositoryManager;
 use Mockery;
+use PHPUnit\Framework\Attributes\Before;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Console\Output\StreamOutput;
 use WyriHaximus\Broadcast\Dummy\AsyncListener;
 use WyriHaximus\Broadcast\Dummy\Event;
 use WyriHaximus\Broadcast\Dummy\Listener;
+use WyriHaximus\Composer\GenerativePluginTooling\FailedReflectionsStore;
 use WyriHaximus\Composer\GenerativePluginTooling\GenerativePluginExecutioner;
 use WyriHaximus\Composer\GenerativePluginTooling\Item as ItemContract;
 use WyriHaximus\TestUtilities\TestCase;
@@ -151,5 +153,11 @@ final class OperatorsTest extends TestCase
         usort($items, static fn (ItemContract $a, ItemContract $b): int => (string) json_encode($a) <=> (string) json_encode($b));
 
         yield from $items;
+    }
+
+    #[Before]
+    public function resetRFS(): void
+    {
+        FailedReflectionsStore::reset();
     }
 }


### PR DESCRIPTION
While Singletons aren't great normally, in this very specific situation it's very helpful to carry state across plugins during Composer Pluging execution so we don't have to retry a failed reflection.